### PR TITLE
Add missing subscription fields

### DIFF
--- a/lib/fabric/app/models/fabric/subscription.rb
+++ b/lib/fabric/app/models/fabric/subscription.rb
@@ -35,7 +35,7 @@ module Fabric
     field :current_period_start, type: Time
     field :days_until_due, type: Integer
     field :description, type: String
-    field :default_tax_rates, type: Hash
+    field :default_tax_rates, type: Array
     field :discount, type: Hash
     field :ended_at, type: Time
     field :livemode, type: Boolean

--- a/lib/fabric/app/models/fabric/subscription.rb
+++ b/lib/fabric/app/models/fabric/subscription.rb
@@ -13,37 +13,56 @@ module Fabric
       primary_key: :stripe_id
     belongs_to :latest_invoice, class_name: 'Fabric::Invoice',
       primary_key: :stripe_id, foreign_key: :latest_invoice_id, inverse_of: nil
+    belongs_to :pending_setup_intent, class_name: 'Fabric::SetupIntent',
+      primary_key: :stripe_id, foreign_key: :pending_setup_intent_id,
+      inverse_of: nil
 
     alias_method :items, :subscription_items
 
     field :stripe_id, type: String
     field :application_fee_percent, type: Float
+    field :automatic_tax, type: Hash
+    field :billing_cycle_anchor, type: Time
+    field :billing_thresholds, type: Hash
+    field :cancel_at, type: Time
     field :cancel_at_period_end, type: Boolean
     field :canceled_at, type: Time
+    field :cancellation_details, type: Hash
+    field :collection_method, type: String
     field :created, type: Time
+    field :currency, type: String
     field :current_period_end, type: Time
     field :current_period_start, type: Time
-    field :start, type: Time
+    field :days_until_due, type: Integer
+    field :description, type: String
+    field :default_tax_rates, type: Hash
+    field :discount, type: Hash
+    field :ended_at, type: Time
+    field :livemode, type: Boolean
+    field :next_pending_invoice_item_invoice, type: Time
+    field :metadata, type: Hash
+    field :pause_collection, type: Hash
+    field :payment_settings, type: Hash
+    field :pending_invoice_item_interval, type: Hash
+    field :pending_update, type: Hash
+    field :start_date, type: Time
     field :status, type: String
     enumerize :status, in: %w[
       trialing active past_due canceled unpaid incomplete incomplete_expired
+      paused
     ]
-    field :ended_at, type: Time
-    field :livemode, type: Boolean
-    field :metadata, type: Hash
     field :tax_percent, type: Float
     field :trial_end, type: Time
+    field :trial_settings, type: Hash
     field :trial_start, type: Time
-    field :discount, type: Hash
 
     validates_uniqueness_of :stripe_id
-    validates :stripe_id, :cancel_at_period_end, :customer_id, :start, :status,
-              :current_period_end, :current_period_start, presence: true
+    validates_presence_of :stripe_id, :customer_id, :status
 
     scope :active, -> { where(status: 'active') }
     scope :billing, -> { where(:status.in => %w[trialing active past_due]) }
     scope :non_canceled, lambda {
-      where(:status.in => %w[trialing active past_due unpaid])
+      where(:status.in => %w[trialing active past_due unpaid paused])
     }
     scope :unpaid, -> { where(:status.in => %w[unpaid past_due]) }
 
@@ -53,23 +72,42 @@ module Fabric
     def sync_with(sub)
       self.stripe_id = sub.id
       self.application_fee_percent = sub.application_fee_percent
+      self.automatic_tax = handle_hash(sub.automatic_tax)
+      self.billing_cycle_anchor = sub.billing_cycle_anchor
+      self.billing_thresholds = handle_hash(sub.billing_thresholds)
+      self.cancel_at = sub.cancel_at
       self.cancel_at_period_end = sub.cancel_at_period_end
       self.canceled_at = sub.canceled_at
+      self.cancellation_details = handle_hash(sub.cancellation_details)
+      self.collection_method = sub.collection_method
       self.created = sub.created
+      self.currency = sub.currency
       self.current_period_end = sub.current_period_end
       self.current_period_start = sub.current_period_start
-      self.start = sub.start
-      self.status = sub.status
+      self.customer_id = handle_expanded(sub.customer)
+      self.days_until_due = sub.days_until_due
+      self.default_payment_method_id = handle_expanded(sub.default_payment_method)
+      self.default_tax_rates = sub.default_tax_rates.map do |dtr_hash|
+        handle_hash(dtr_hash)
+      end
+      self.description = sub.description
+      self.discount = handle_hash(sub.discount)
       self.ended_at = sub.ended_at
+      self.latest_invoice_id = handle_expanded(sub.latest_invoice)
       self.livemode = sub.livemode
       self.metadata = convert_metadata(sub.metadata)
+      self.next_pending_invoice_item_invoice = sub.next_pending_invoice_item_invoice
+      self.pause_collection = handle_hash(sub.pause_collection)
+      self.payment_settings = handle_hash(sub.payment_settings)
+      self.pending_invoice_item_interval = handle_hash(sub.pending_invoice_item_interval)
+      self.pending_setup_intent_id = handle_expanded(sub.pending_setup_intent)
+      self.pending_update = handle_hash(sub.pending_update)
+      self.start_date = sub.start_date
+      self.status = sub.status
       self.tax_percent = sub.tax_percent
       self.trial_end = sub.trial_end
+      self.trial_settings = handle_hash(sub.trial_settings)
       self.trial_start = sub.trial_start
-      self.customer_id = handle_expanded(sub.customer)
-      self.default_payment_method_id = handle_expanded(sub.default_payment_method)
-      self.discount = handle_hash(sub.discount)
-      self.latest_invoice_id = handle_expanded(sub.latest_invoice)
       self
     end
 

--- a/test/helpers/relationship_helper.rb
+++ b/test/helpers/relationship_helper.rb
@@ -68,7 +68,6 @@ def subscription
     customer_id: 'cust_xxx',
     default_payment_method_id: 'pm_xxx',
     cancel_at_period_end: false,
-    start: Time.now,
     status: 'active',
     current_period_end: 1.month.from_now,
     current_period_start: Time.now

--- a/test/test_billing_policy.rb
+++ b/test/test_billing_policy.rb
@@ -33,7 +33,6 @@ class TestBillingPolicy < Minitest::Test
       stripe_id: 'sub_0',
       cancel_at_period_end: false,
       customer: customer,
-      start: Time.now,
       status: 'active',
       current_period_end: 30.days.from_now,
       current_period_start: Time.now
@@ -63,7 +62,6 @@ class TestBillingPolicy < Minitest::Test
       stripe_id: 'sub_0',
       cancel_at_period_end: false,
       customer: customer,
-      start: Time.now,
       status: 'past_due',
       current_period_end: 30.days.from_now,
       current_period_start: Time.now
@@ -125,7 +123,6 @@ class TestBillingPolicy < Minitest::Test
       stripe_id: 'sub_0',
       cancel_at_period_end: false,
       customer: customer,
-      start: Time.now,
       status: 'unpaid',
       current_period_end: 30.days.from_now,
       current_period_start: Time.now
@@ -145,7 +142,6 @@ class TestBillingPolicy < Minitest::Test
       stripe_id: 'sub_0',
       cancel_at_period_end: false,
       customer: customer,
-      start: Time.now,
       status: 'active',
       current_period_end: 30.days.from_now,
       current_period_start: Time.now


### PR DESCRIPTION
## Changes
- add missing fields
- reorder all fields alphabetically
- fix tests
- removed `start` since it's replaced by `started_date`
- removed validations that only can cause problems
- added `paused` value for `status`
- fixes #23 

## Resync subscriptions
### Sync Class
```ruby
require 'ruby-limiter'

class SyncSubscriptions
  extend Limiter::Mixin

  limit_method :update_subscription, rate: 75, interval: 1, balanced: true

  def run
    subscriptions = Fabric::Subscription.all
    total_subscriptions = subscriptions.count
    subscriptions.each_with_index do |subscription, i|
      print "Updating: #{i}/#{total_subscriptions}\r"
      update_subscription(subscription)
    end;
  end

  def update_subscription(subscription)
    begin
      subscription.sync_from_stripe
      subscription.save
    rescue => e
      if e.to_s.include?('404')
        subscription.destroy 
      else
        puts "Error: #{e} (#{subscription.stripe_id})"
      end
    end
  end

end
```
### Run
```ruby
SyncSubscriptions.new.run