### PR TITLE
Add Funding Instructions for Customer

### DIFF
--- a/lib/fabric.rb
+++ b/lib/fabric.rb
@@ -113,6 +113,7 @@ module Fabric
   autoload :Dispute, 'fabric/app/models/fabric/dispute'
   autoload :Event, 'fabric/app/models/fabric/event'
   autoload :File, 'fabric/app/models/fabric/file'
+  autoload :FundingInstructions, 'fabric/app/models/fabric/funding_instructions'
   autoload :Invoice, 'fabric/app/models/fabric/invoice'
   autoload :InvoiceItem, 'fabric/app/models/fabric/invoice_item'
   autoload :PaymentIntent, 'fabric/app/models/fabric/payment_intent'

--- a/lib/fabric/app/models/fabric/customer.rb
+++ b/lib/fabric/app/models/fabric/customer.rb
@@ -27,6 +27,8 @@ module Fabric
     has_many :tax_ids, class_name: 'Fabric::TaxId',
       primary_key: :stripe_id, dependent: :destroy
 
+    embeds_one :funding_instructions, class_name: 'Fabric::FundingInstructions'
+
     field :stripe_id, type: String
     field :object, type: String
     field :account_balance, type: Integer, default: 0 # deprecated

--- a/lib/fabric/app/models/fabric/funding_instructions.rb
+++ b/lib/fabric/app/models/fabric/funding_instructions.rb
@@ -1,0 +1,36 @@
+module Fabric
+  class FundingInstructions
+    include Base
+    include Mongoid::Document
+    include Mongoid::Timestamps
+
+    embedded_in :customer, class_name: 'Fabric::Customer'
+
+    field :object, type: String
+    field :bank_transfer, type: Hash, default: { type: 'us_bank_transfer' }
+    field :currency, type: String, default: 'usd'
+    field :funding_type, type: String, default: 'bank_transfer'
+    field :livemode, type: Boolean
+
+    def sync_with(funding_instructions)
+      self.object = funding_instructions.object
+      self.bank_transfer = handle_hash(funding_instructions.bank_transfer)
+      self.currency = funding_instructions.currency
+      self.funding_type = funding_instructions.funding_type
+      self.livemode = funding_instructions.livemode
+      self
+    end
+
+    def sync_from_stripe
+      stripe_customer = Stripe::Customer.retrieve(customer.stripe_id)
+      stripe_funding_instructions = stripe_customer.create_funding_instructions(
+        currency: self.currency,
+        funding_type: self.funding_type,
+        bank_transfer: { type: self.bank_transfer[:type] }
+      )
+      sync_with(stripe_funding_instructions)
+      self
+    end
+
+  end
+end


### PR DESCRIPTION
Added embeded model for Funding Instructions on customer. This is a very unique situation since Funding Instructions do not have a Stripe ID. The only reasonable option was to embed them.